### PR TITLE
Option to decouple learning rate and max_grad_norm

### DIFF
--- a/opacus/optimizers/ddp_perlayeroptimizer.py
+++ b/opacus/optimizers/ddp_perlayeroptimizer.py
@@ -27,11 +27,17 @@ from .optimizer import DPOptimizer, _generate_noise
 from .perlayeroptimizer import DPPerLayerOptimizer
 
 
-def _clip_and_accumulate_parameter(p: nn.Parameter, max_grad_norm: float):
+def _clip_and_accumulate_parameter(
+    p: nn.Parameter, max_grad_norm: float, normalize_clipping: bool
+):
     per_sample_norms = p.grad_sample.view(len(p.grad_sample), -1).norm(2, dim=-1)
     per_sample_clip_factor = (max_grad_norm / (per_sample_norms + 1e-6)).clamp(max=1.0)
 
     grad = contract("i,i...", per_sample_clip_factor, p.grad_sample)
+
+    if normalize_clipping:
+        grad /= max_grad_norm
+
     if p.summed_grad is not None:
         p.summed_grad += grad
     else:
@@ -49,6 +55,7 @@ class SimpleDistributedPerLayerOptimizer(DPPerLayerOptimizer, DistributedDPOptim
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
+        normalize_clipping: bool = False,
     ):
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()
@@ -61,6 +68,7 @@ class SimpleDistributedPerLayerOptimizer(DPPerLayerOptimizer, DistributedDPOptim
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
+            normalize_clipping=normalize_clipping,
         )
 
 
@@ -80,6 +88,7 @@ class DistributedPerLayerOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
+        normalize_clipping: bool = False,
     ):
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()
@@ -93,6 +102,7 @@ class DistributedPerLayerOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
+            normalize_clipping=normalize_clipping,
         )
         self._register_hooks()
 
@@ -100,8 +110,11 @@ class DistributedPerLayerOptimizer(DPOptimizer):
         """
         The reason why we need self is because of generator for secure_mode
         """
+
+        max_grad_norm = 1 if self.normalize_cliping else self.max_grad_norm
+
         noise = _generate_noise(
-            std=self.noise_multiplier * self.max_grad_norm,
+            std=self.noise_multiplier * max_grad_norm,
             reference=p.summed_grad,
             generator=None,
             secure_mode=self.secure_mode,
@@ -146,9 +159,13 @@ class DistributedPerLayerOptimizer(DPOptimizer):
         return True
 
     def _ddp_per_layer_hook(
-        self, p: nn.Parameter, max_grad_norm: float, _: torch.Tensor
+        self,
+        p: nn.Parameter,
+        max_grad_norm: float,
+        normalize_clipping: bool,
+        _: torch.Tensor,
     ):
-        _clip_and_accumulate_parameter(p, max_grad_norm)
+        _clip_and_accumulate_parameter(p, max_grad_norm, normalize_clipping)
         # Equivalent ot _check_skip_next_step but without popping because it has to be done for every parameter p
         if self._check_skip_next_step(pop_next=False):
             return
@@ -170,5 +187,12 @@ class DistributedPerLayerOptimizer(DPOptimizer):
                 p.ddp_hooks = []
 
             p.ddp_hooks.append(
-                p.register_hook(partial(self._ddp_per_layer_hook, p, max_grad_norm))
+                p.register_hook(
+                    partial(
+                        self._ddp_per_layer_hook,
+                        p,
+                        max_grad_norm,
+                        self.normalize_clipping,
+                    )
+                )
             )

--- a/opacus/optimizers/ddpoptimizer.py
+++ b/opacus/optimizers/ddpoptimizer.py
@@ -38,6 +38,7 @@ class DistributedDPOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
+        normalize_clipping: bool = False,
     ):
         super().__init__(
             optimizer,
@@ -47,6 +48,7 @@ class DistributedDPOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
+            normalize_clipping=normalize_clipping,
         )
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -204,6 +204,7 @@ class DPOptimizer(Optimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
+        normalize_clipping: bool = False,
     ):
         """
 
@@ -222,6 +223,10 @@ class DPOptimizer(Optimizer):
             secure_mode: if ``True`` uses noise generation approach robust to floating
                 point arithmetic attacks.
                 See :meth:`~opacus.optimizers.optimizer._generate_noise` for details
+            normalize_clipping: Decouples the learning rate and max_grad_norm by normalizing the
+                clipped gradients by 1/C as described in the paper "Unlocking High-Accuracy
+                Differentially Private Image Classification through Scale" by De et al. (2022)
+                - https://arxiv.org/pdf/2204.13650.pdf
         """
         if loss_reduction not in ("mean", "sum"):
             raise ValueError(f"Unexpected value for loss_reduction: {loss_reduction}")
@@ -239,6 +244,7 @@ class DPOptimizer(Optimizer):
         self.step_hook = None
         self.generator = generator
         self.secure_mode = secure_mode
+        self.normalize_clipping = normalize_clipping
 
         self.param_groups = self.original_optimizer.param_groups
         self.defaults = self.original_optimizer.defaults
@@ -411,6 +417,9 @@ class DPOptimizer(Optimizer):
             grad_sample = self._get_flat_grad_sample(p)
             grad = contract("i,i...", per_sample_clip_factor, grad_sample)
 
+            if self.normalize_clipping:
+                grad /= self.max_grad_norm
+
             if p.summed_grad is not None:
                 p.summed_grad += grad
             else:
@@ -423,11 +432,13 @@ class DPOptimizer(Optimizer):
         Adds noise to clipped gradients. Stores clipped and noised result in ``p.grad``
         """
 
+        max_grad_norm = 1 if self.normalize_clipping else self.max_grad_norm
+
         for p in self.params:
             _check_processed_flag(p.summed_grad)
 
             noise = _generate_noise(
-                std=self.noise_multiplier * self.max_grad_norm,
+                std=self.noise_multiplier * max_grad_norm,
                 reference=p.summed_grad,
                 generator=self.generator,
                 secure_mode=self.secure_mode,

--- a/opacus/optimizers/perlayeroptimizer.py
+++ b/opacus/optimizers/perlayeroptimizer.py
@@ -40,6 +40,7 @@ class DPPerLayerOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
+        normalize_clipping: bool = False,
     ):
         assert len(max_grad_norm) == len(params(optimizer))
         self.max_grad_norms = max_grad_norm
@@ -52,6 +53,7 @@ class DPPerLayerOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
+            normalize_clipping=normalize_clipping,
         )
 
     def clip_and_accumulate(self):
@@ -66,6 +68,9 @@ class DPPerLayerOptimizer(DPOptimizer):
                 max=1.0
             )
             grad = contract("i,i...", per_sample_clip_factor, grad_sample)
+
+            if self.normalize_clipping:
+                grad /= max_grad_norm
 
             if p.summed_grad is not None:
                 p.summed_grad += grad

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -110,6 +110,7 @@ class PrivacyEngine:
         clipping: str = "flat",
         noise_generator=None,
         grad_sample_mode="hooks",
+        normalize_clipping: bool = False,
     ) -> DPOptimizer:
         if isinstance(optimizer, DPOptimizer):
             optimizer = optimizer.original_optimizer
@@ -134,6 +135,7 @@ class PrivacyEngine:
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=self.secure_mode,
+            normalize_clipping=normalize_clipping,
         )
 
     def _prepare_data_loader(
@@ -274,6 +276,7 @@ class PrivacyEngine:
         clipping: str = "flat",
         noise_generator=None,
         grad_sample_mode: str = "hooks",
+        normalize_clipping: bool = False,
     ) -> Tuple[GradSampleModule, DPOptimizer, DataLoader]:
         """
         Add privacy-related responsibilities to the main PyTorch training objects:
@@ -322,6 +325,10 @@ class PrivacyEngine:
                 implementation class for the wrapped ``module``. See
                 :class:`~opacus.grad_sample.gsm_base.AbstractGradSampleModule` for more
                 details
+            normalize_clipping: Decouples the learning rate and max_grad_norm by normalizing the
+                clipped gradients by 1/C as described in the paper "Unlocking High-Accuracy
+                Differentially Private Image Classification through Scale" by De et al. (2022)
+                - https://arxiv.org/pdf/2204.13650.pdf
 
         Returns:
             Tuple of (model, optimizer, data_loader).
@@ -380,6 +387,7 @@ class PrivacyEngine:
             distributed=distributed,
             clipping=clipping,
             grad_sample_mode=grad_sample_mode,
+            normalize_clipping=normalize_clipping,
         )
 
         optimizer.attach_step_hook(
@@ -404,6 +412,7 @@ class PrivacyEngine:
         clipping: str = "flat",
         noise_generator=None,
         grad_sample_mode: str = "hooks",
+        normalize_clipping: bool = False,
         **kwargs,
     ):
         """
@@ -487,6 +496,7 @@ class PrivacyEngine:
             grad_sample_mode=grad_sample_mode,
             poisson_sampling=poisson_sampling,
             clipping=clipping,
+            normalize_clipping=normalize_clipping,
         )
 
     def get_epsilon(self, delta):

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -108,6 +108,7 @@ class BasePrivacyEngineTest(ABC):
         clipping: str = "flat",
         grad_sample_mode="hooks",
         opt_exclude_frozen=False,
+        normalize_clipping=False,
     ):
         model = self._init_model()
         model = PrivacyEngine.get_compatible_module(model)
@@ -139,6 +140,7 @@ class BasePrivacyEngineTest(ABC):
             poisson_sampling=poisson_sampling,
             clipping=clipping,
             grad_sample_mode=grad_sample_mode,
+            normalize_clipping=normalize_clipping,
         )
 
         return model, optimizer, poisson_dl, privacy_engine
@@ -314,6 +316,39 @@ class BasePrivacyEngineTest(ABC):
         self.assertAlmostEqual(clipped_grads.norm().item(), max_grad_norm, places=3)
         self.assertGreater(non_clipped_grads.norm(), clipped_grads.norm())
 
+    def test_flat_clipping_with_normalize(self):
+        # FIXME
+        torch.set_printoptions(sci_mode=False, precision=6)
+
+        self.BATCH_SIZE = 1
+        max_grad_norm = 0.5
+
+        torch.manual_seed(1337)
+        model, optimizer, dl, _ = self._init_private_training(
+            noise_multiplier=0.0,
+            max_grad_norm=max_grad_norm,
+            clipping="flat",
+            poisson_sampling=False,
+            grad_sample_mode=self.GRAD_SAMPLE_MODE,
+            normalize_clipping=True,
+        )
+        self._train_steps(model, optimizer, dl, max_steps=1)
+        clipped_grads = torch.cat(
+            [p.summed_grad.reshape(-1) for p in model.parameters() if p.requires_grad]
+        )
+
+        torch.manual_seed(1337)
+        model, optimizer, dl = self._init_vanilla_training()
+        self._train_steps(model, optimizer, dl, max_steps=1)
+        non_clipped_grads = torch.cat(
+            [p.grad.reshape(-1) for p in model.parameters() if p.requires_grad]
+        )
+
+        self.assertAlmostEqual(
+            clipped_grads.norm().item() * max_grad_norm, max_grad_norm, places=3
+        )
+        self.assertGreater(non_clipped_grads.norm(), clipped_grads.norm())
+
     def test_per_layer_clipping(self):
         self.BATCH_SIZE = 1
         max_grad_norm_per_layer = 1.0
@@ -344,6 +379,41 @@ class BasePrivacyEngineTest(ABC):
                 min(non_clipped_norm, max_grad_norm_per_layer), clipped_norm, places=3
             )
 
+    def test_per_layer_clipping_with_normalize(self):
+        self.BATCH_SIZE = 1
+        max_grad_norm_per_layer = 1.0
+
+        torch.manual_seed(1337)
+        p_model, p_optimizer, p_dl, _ = self._init_private_training(
+            noise_multiplier=0.0,
+            max_grad_norm=max_grad_norm_per_layer,
+            clipping="per_layer",
+            poisson_sampling=False,
+            grad_sample_mode=self.GRAD_SAMPLE_MODE,
+            normalize_clipping=True,
+        )
+        p_optimizer.signal_skip_step()
+        self._train_steps(p_model, p_optimizer, p_dl, max_steps=1)
+
+        torch.manual_seed(1337)
+        v_model, v_optimizer, v_dl = self._init_vanilla_training()
+        self._train_steps(v_model, v_optimizer, v_dl, max_steps=1)
+
+        for p_p, v_p in zip(p_model.parameters(), v_model.parameters()):
+            if not p_p.requires_grad:
+                continue
+
+            non_clipped_norm = v_p.grad.norm().item()
+            clipped_norm = p_p.summed_grad.norm().item()
+
+            self.assertAlmostEqual(
+                min(
+                    non_clipped_norm * max_grad_norm_per_layer, max_grad_norm_per_layer
+                ),
+                clipped_norm,
+                places=3,
+            )
+
     def test_sample_grad_aggregation(self):
         """
         Check if final gradient is indeed an aggregation over per-sample gradients
@@ -367,6 +437,31 @@ class BasePrivacyEngineTest(ABC):
                 f"Param: {p_name}",
             )
 
+    def test_sample_grad_aggregation_with_normalize(self):
+        """
+        Check if final gradient is indeed an aggregation over per-sample gradients
+        """
+        max_grad_norm = 99999.0
+        model, optimizer, dl, _ = self._init_private_training(
+            poisson_sampling=False,
+            noise_multiplier=0.0,
+            max_grad_norm=max_grad_norm,
+            grad_sample_mode=self.GRAD_SAMPLE_MODE,
+            normalize_clipping=True,
+        )
+        self._train_steps(model, optimizer, dl, max_steps=1)
+
+        for p_name, p in model.named_parameters():
+            if not p.requires_grad:
+                continue
+
+            summed_grad = p.grad_sample.sum(dim=0) / self.BATCH_SIZE / max_grad_norm
+            self.assertTrue(
+                torch.allclose(p.grad, summed_grad, atol=1e-8, rtol=1e-4),
+                f"Per sample gradients don't sum up to the final grad value."
+                f"Param: {p_name}",
+            )
+
     def test_noise_changes_every_time(self):
         """
         Test that adding noise results in ever different model params.
@@ -374,6 +469,28 @@ class BasePrivacyEngineTest(ABC):
         """
         model, optimizer, dl, _ = self._init_private_training(
             poisson_sampling=False, grad_sample_mode=self.GRAD_SAMPLE_MODE
+        )
+        self._train_steps(model, optimizer, dl, max_steps=1)
+        first_run_params = (p for p in model.parameters() if p.requires_grad)
+
+        model, optimizer, dl, _ = self._init_private_training(
+            poisson_sampling=False, grad_sample_mode=self.GRAD_SAMPLE_MODE
+        )
+        self._train_steps(model, optimizer, dl, max_steps=1)
+        second_run_params = (p for p in model.parameters() if p.requires_grad)
+
+        for p0, p1 in zip(first_run_params, second_run_params):
+            self.assertFalse(torch.allclose(p0, p1))
+
+    def test_noise_changes_every_time_with_normalize(self):
+        """
+        Test that adding noise results in ever different model params.
+        We disable clipping in this test by setting it to a very high threshold.
+        """
+        model, optimizer, dl, _ = self._init_private_training(
+            poisson_sampling=False,
+            grad_sample_mode=self.GRAD_SAMPLE_MODE,
+            normalize_clipping=True,
         )
         self._train_steps(model, optimizer, dl, max_steps=1)
         first_run_params = (p for p in model.parameters() if p.requires_grad)
@@ -658,6 +775,7 @@ class BasePrivacyEngineTest(ABC):
         noise_multiplier=st.floats(0.5, 5.0),
         max_steps=st.integers(8, 10),
         secure_mode=st.just(False),  # TODO: enable after fixing torchcsprng build
+        normalize_clipping=st.booleans(),
     )
     @settings(deadline=None)
     def test_noise_level(
@@ -665,13 +783,17 @@ class BasePrivacyEngineTest(ABC):
         noise_multiplier: float,
         max_steps: int,
         secure_mode: bool,
+        normalize_clipping: bool,
     ):
         """
         Tests that the noise level is correctly set
         """
 
         def helper_test_noise_level(
-            noise_multiplier: float, max_steps: int, secure_mode: bool
+            noise_multiplier: float,
+            max_steps: int,
+            secure_mode: bool,
+            normalize_clipping: bool,
         ):
             torch.manual_seed(100)
             # Initialize models with parameters to zero
@@ -679,6 +801,7 @@ class BasePrivacyEngineTest(ABC):
                 noise_multiplier=noise_multiplier,
                 secure_mode=secure_mode,
                 grad_sample_mode=self.GRAD_SAMPLE_MODE,
+                normalize_clipping=normalize_clipping,
             )
             for p in model.parameters():
                 p.data.zero_()
@@ -717,6 +840,7 @@ class BasePrivacyEngineTest(ABC):
             noise_multiplier=noise_multiplier,
             max_steps=max_steps,
             secure_mode=secure_mode,
+            normalize_clipping=normalize_clipping,
         )
 
     @unittest.skip("requires torchcsprng compatible with new pytorch versions")


### PR DESCRIPTION
- Added a `normalize_clipping` parameter to PrivacyEngine's make_private and make_private_private with epsilon for decoupling the learning rate and max gradient norm by normalizing the clipped gradients by 1/C as described in the paper "Unlocking High-Accuracy Differentially Private Image Classification through Scale" by De et al. (2022)
  - https://arxiv.org/pdf/2204.13650.pdf
