### PR TITLE
Step through `total_steps` instead of epochs.

### DIFF
--- a/opacus/accountants/analysis/prv/prvs.py
+++ b/opacus/accountants/analysis/prv/prvs.py
@@ -96,11 +96,15 @@ class TruncatedPrivacyRandomVariable:
         """
         Calculate the mean using numerical integration.
         """
+        # determine points based on t_min and t_max
+        lower_exponent = int(np.log10(np.abs(self.t_min)))
+        upper_exponent = int(np.log10(self.t_max))
         points = np.concatenate(
             [
                 [self.t_min],
-                -np.logspace(-5, -1, 5)[::-1],
-                np.logspace(-5, -1, 5),
+                -np.logspace(start=lower_exponent, stop=-5, num=10),
+                [0],
+                np.logspace(start=-5, stop=upper_exponent, num=10),
                 [self.t_max],
             ]
         )

--- a/opacus/data_loader.py
+++ b/opacus/data_loader.py
@@ -205,7 +205,7 @@ class DPDataLoader(DataLoader):
 
         # DataLoader does not know about steps, it's handled by
         # our batch sampler, so let's remove it from kwargs
-        kwargs.pop('total_steps', None)
+        kwargs.pop("total_steps", None)
 
         super().__init__(
             dataset=dataset,

--- a/opacus/data_loader.py
+++ b/opacus/data_loader.py
@@ -149,6 +149,7 @@ class DPDataLoader(DataLoader):
         drop_last: bool = False,
         generator=None,
         distributed: bool = False,
+        total_steps: int = None,
         **kwargs,
     ):
         """
@@ -170,6 +171,9 @@ class DPDataLoader(DataLoader):
             distributed: set ``True`` if you'll be using DPDataLoader in a DDP environment
                 Selects between ``DistributedUniformWithReplacementSampler`` and
                 ``UniformWithReplacementSampler`` sampler implementations
+            total_steps: Instead of stepping through once the dataloader for once expected epoch,
+            we will step through it `total_steps` times. This will set the sample rate to
+            batch_size/data_size. The parameter total_steps is any positive integer.
         """
 
         self.sample_rate = sample_rate
@@ -180,12 +184,14 @@ class DPDataLoader(DataLoader):
                 total_size=len(dataset),  # type: ignore[assignment, arg-type]
                 sample_rate=sample_rate,
                 generator=generator,
+                steps=total_steps,
             )
         else:
             batch_sampler = UniformWithReplacementSampler(
                 num_samples=len(dataset),  # type: ignore[assignment, arg-type]
                 sample_rate=sample_rate,
                 generator=generator,
+                steps=total_steps,
             )
         sample_empty_shapes = [(0, *shape_safe(x)) for x in dataset[0]]
         dtypes = [dtype_safe(x) for x in dataset[0]]
@@ -196,6 +202,10 @@ class DPDataLoader(DataLoader):
             logger.warning(
                 "Ignoring drop_last as it is not compatible with DPDataLoader."
             )
+
+        # DataLoader does not know about steps, it's handled by
+        # our batch sampler, so let's remove it from kwargs
+        kwargs.pop('total_steps', None)
 
         super().__init__(
             dataset=dataset,
@@ -211,7 +221,12 @@ class DPDataLoader(DataLoader):
 
     @classmethod
     def from_data_loader(
-        cls, data_loader: DataLoader, *, distributed: bool = False, generator=None
+        cls,
+        data_loader: DataLoader,
+        *,
+        distributed: bool = False,
+        generator=None,
+        total_steps: int = None,
     ):
         """
         Creates new ``DPDataLoader`` based on passed ``data_loader`` argument.
@@ -221,6 +236,9 @@ class DPDataLoader(DataLoader):
             distributed: set ``True`` if you'll be using DPDataLoader in a DDP environment
             generator: Random number generator used to sample elements. Defaults to
                 generator from the original data loader.
+            total_steps: Instead of stepping through once the dataloader for once expected epoch,
+            we will step through it `total_steps` times. This will set the sample rate to
+            batch_size/data_size. The parameter total_steps is any positive integer.
 
         Returns:
             New DPDataLoader instance, with all attributes and parameters inherited
@@ -236,9 +254,14 @@ class DPDataLoader(DataLoader):
         if isinstance(data_loader.dataset, IterableDataset):
             raise ValueError("Uniform sampling is not supported for IterableDataset")
 
+        if total_steps:
+            sample_rate = data_loader.batch_size / len(data_loader.dataset)
+        else:
+            sample_rate = 1 / len(data_loader)
+
         return cls(
             dataset=data_loader.dataset,
-            sample_rate=1 / len(data_loader),
+            sample_rate=sample_rate,
             num_workers=data_loader.num_workers,
             collate_fn=data_loader.collate_fn,
             pin_memory=data_loader.pin_memory,
@@ -250,6 +273,7 @@ class DPDataLoader(DataLoader):
             prefetch_factor=data_loader.prefetch_factor,
             persistent_workers=data_loader.persistent_workers,
             distributed=distributed,
+            total_steps=total_steps,
         )
 
 

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -500,6 +500,9 @@ class PrivacyEngine:
             if not poisson_sampling:
                 raise ValueError("Setting total_steps without Poisson sampling not implemented")
 
+            if epochs != 1:
+                raise ValueError("Epochs must be 1 when 'total_steps' is set")
+
             # we are given the number of optimizer steps instead of epochs,
             # so we can just use sample rate q = B/N
             sample_rate = data_loader.batch_size / len(data_loader.dataset)

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -385,7 +385,9 @@ class PrivacyEngine:
 
         if total_steps:
             if not poisson_sampling:
-                raise ValueError("Setting total_steps without Poisson sampling not implemented")
+                raise ValueError(
+                    "Setting total_steps without Poisson sampling not implemented"
+                )
 
             # if we are stepping through the optimizer for `total_steps` steps,
             # we can just use sample_rate q = B/N
@@ -498,7 +500,9 @@ class PrivacyEngine:
 
         if total_steps:
             if not poisson_sampling:
-                raise ValueError("Setting total_steps without Poisson sampling not implemented")
+                raise ValueError(
+                    "Setting total_steps without Poisson sampling not implemented"
+                )
 
             if epochs is not None:
                 raise ValueError(

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -500,8 +500,10 @@ class PrivacyEngine:
             if not poisson_sampling:
                 raise ValueError("Setting total_steps without Poisson sampling not implemented")
 
-            if epochs != 1:
-                raise ValueError("Epochs must be 1 when 'total_steps' is set")
+            if epochs is not None:
+                raise ValueError(
+                    "make_private_with_epsilon takes as input EITHER a number of steps or a number of epochs"
+                )
 
             # we are given the number of optimizer steps instead of epochs,
             # so we can just use sample rate q = B/N

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -583,7 +583,9 @@ class BasePrivacyEngineTest(ABC):
         data_size=st.sampled_from([50, 51]),
     )
     @settings(deadline=None)
-    def test_make_private_with_epsilon_with_total_steps(self, total_steps, batch_size, data_size):
+    def test_make_private_with_epsilon_with_total_steps(
+        self, total_steps, batch_size, data_size
+    ):
         # save the original values, as we are going to test
         # different data and batch sizes
         orig_data_size = self.DATA_SIZE
@@ -603,7 +605,7 @@ class BasePrivacyEngineTest(ABC):
             data_loader=dl,
             target_epsilon=target_eps,
             target_delta=1e-5,
-            epochs=None, # epochs must be None if total_steps is set
+            epochs=None,  # epochs must be None if total_steps is set
             max_grad_norm=1.0,
             grad_sample_mode=self.GRAD_SAMPLE_MODE,
             total_steps=total_steps,
@@ -615,7 +617,7 @@ class BasePrivacyEngineTest(ABC):
 
         # we can check from the accounting history if the sample rate
         # is indeed set correctly.
-        for i in range(1, total_steps+1):
+        for i in range(1, total_steps + 1):
             self._train_steps(model, optimizer, poisson_dl, max_steps=1)
 
             history = privacy_engine.accountant.history[0]

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -595,7 +595,6 @@ class BasePrivacyEngineTest(ABC):
         model, optimizer, dl = self._init_vanilla_training()
         target_eps = 2.0
         target_delta = 1e-5
-        epochs = 1
 
         privacy_engine = PrivacyEngine()
         model, optimizer, poisson_dl = privacy_engine.make_private_with_epsilon(
@@ -604,7 +603,7 @@ class BasePrivacyEngineTest(ABC):
             data_loader=dl,
             target_epsilon=target_eps,
             target_delta=1e-5,
-            epochs=epochs,
+            epochs=None, # epochs must be None if total_steps is set
             max_grad_norm=1.0,
             grad_sample_mode=self.GRAD_SAMPLE_MODE,
             total_steps=total_steps,
@@ -630,6 +629,21 @@ class BasePrivacyEngineTest(ABC):
         # restore the original values
         self.DATA_SIZE = orig_data_size
         self.BATCH_SIZE = orig_batch_size
+
+        with self.assertRaisesRegex(
+            ValueError, "EITHER a number of steps or a number of epochs"
+        ):
+            model, optimizer, poisson_dl = privacy_engine.make_private_with_epsilon(
+                module=model,
+                optimizer=optimizer,
+                data_loader=dl,
+                target_epsilon=target_eps,
+                target_delta=1e-5,
+                epochs=1,
+                max_grad_norm=1.0,
+                grad_sample_mode=self.GRAD_SAMPLE_MODE,
+                total_steps=100,
+            )
 
     def test_deterministic_run(self):
         """

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -609,6 +609,8 @@ class BasePrivacyEngineTest(ABC):
             total_steps=total_steps,
         )
 
+        self.assertEqual(len(poisson_dl), total_steps)
+
         true_sample_rate = self.BATCH_SIZE / self.DATA_SIZE
 
         # we can check from the accounting history if the sample rate
@@ -630,6 +632,7 @@ class BasePrivacyEngineTest(ABC):
         self.DATA_SIZE = orig_data_size
         self.BATCH_SIZE = orig_batch_size
 
+        # check that error is thrown when both epochs and total_steps are set
         with self.assertRaisesRegex(
             ValueError, "EITHER a number of steps or a number of epochs"
         ):

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -109,6 +109,7 @@ class BasePrivacyEngineTest(ABC):
         grad_sample_mode="hooks",
         opt_exclude_frozen=False,
         normalize_clipping=False,
+        total_steps: int = None,
     ):
         model = self._init_model()
         model = PrivacyEngine.get_compatible_module(model)
@@ -141,6 +142,7 @@ class BasePrivacyEngineTest(ABC):
             clipping=clipping,
             grad_sample_mode=grad_sample_mode,
             normalize_clipping=normalize_clipping,
+            total_steps=total_steps,
         )
 
         return model, optimizer, poisson_dl, privacy_engine
@@ -574,6 +576,60 @@ class BasePrivacyEngineTest(ABC):
         self.assertAlmostEqual(
             target_eps, privacy_engine.get_epsilon(target_delta), places=2
         )
+
+    @given(
+        total_steps=st.sampled_from([1, 3, 26]),
+        batch_size=st.sampled_from([25, 49, 50]),
+        data_size=st.sampled_from([50, 51]),
+    )
+    @settings(deadline=None)
+    def test_make_private_with_epsilon_with_total_steps(self, total_steps, batch_size, data_size):
+        # save the original values, as we are going to test
+        # different data and batch sizes
+        orig_data_size = self.DATA_SIZE
+        orig_batch_size = self.BATCH_SIZE
+
+        self.DATA_SIZE = data_size
+        self.BATCH_SIZE = batch_size
+
+        model, optimizer, dl = self._init_vanilla_training()
+        target_eps = 2.0
+        target_delta = 1e-5
+        epochs = 1
+
+        privacy_engine = PrivacyEngine()
+        model, optimizer, poisson_dl = privacy_engine.make_private_with_epsilon(
+            module=model,
+            optimizer=optimizer,
+            data_loader=dl,
+            target_epsilon=target_eps,
+            target_delta=1e-5,
+            epochs=epochs,
+            max_grad_norm=1.0,
+            grad_sample_mode=self.GRAD_SAMPLE_MODE,
+            total_steps=total_steps,
+        )
+
+        true_sample_rate = self.BATCH_SIZE / self.DATA_SIZE
+
+        # we can check from the accounting history if the sample rate
+        # is indeed set correctly.
+        for i in range(1, total_steps+1):
+            self._train_steps(model, optimizer, poisson_dl, max_steps=1)
+
+            history = privacy_engine.accountant.history[0]
+            _, last_sample_rate, num_steps = history
+
+            self.assertEqual(i, num_steps)
+            self.assertEqual(true_sample_rate, last_sample_rate)
+
+        self.assertAlmostEqual(
+            target_eps, privacy_engine.get_epsilon(target_delta), delta=0.01
+        )
+
+        # restore the original values
+        self.DATA_SIZE = orig_data_size
+        self.BATCH_SIZE = orig_batch_size
 
     def test_deterministic_run(self):
         """

--- a/opacus/utils/uniform_sampler.py
+++ b/opacus/utils/uniform_sampler.py
@@ -39,6 +39,7 @@ class UniformWithReplacementSampler(Sampler[List[int]]):
         self.num_samples = num_samples
         self.sample_rate = sample_rate
         self.generator = generator
+        self.steps = steps
 
         if self.num_samples <= 0:
             raise ValueError(
@@ -113,6 +114,7 @@ class DistributedUniformWithReplacementSampler(Sampler):
         self.epoch = 0
         self.shuffle = shuffle
         self.shuffle_seed = shuffle_seed
+        self.steps = steps
 
         if self.total_size <= 0:
             raise ValueError(


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->

Currently only sample rates of 1/num_batches are supported due to the way the data loaders are handled.

To have total control over sample rate, added a parameter `total_steps` to make_private and make_private_with_epsilon. When the parameter is set we will step `total_steps` of times through the data loader instead of approximated epochs. The sample rate is also exactly set to q = B/N.

<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Added a new test `test_make_private_with_epsilon_with_total_steps` to tests/privacy_engine_test.py.

It tests a few different `total_steps`, `data_size`, and `batch_size` combinations and checks that the accounting history in fact contains the correct sample rates. In addition it also check the `target_epsilon` according to the existing `test_make_private_with_epsilon` test.
 
## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [] All tests passed, and additional code has been covered with new tests.

We have been failing to run the Opacus test suite without errors.

However, the change did not introduce any _new_ failing tests.
